### PR TITLE
+Block reward calculation correction

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -72,12 +72,13 @@ class CMainParams : public CChainParams {
 public:
     CMainParams() {
         strNetworkID = "main";
-        consensus.nSubsidyHalvingInterval = 210240; // Note: actual number of blocks per calendar year with DGW v3 is ~200700 (for example 449750 - 249050)
+        // Note: actual number of blocks per calendar year with DGW v3 is ~200700 (for example 449750 - 249050)
+        consensus.nSubsidyHalvingInterval = 498855;
         consensus.nMasternodePaymentsStartBlock = 15; // not true, but it's ok as long as it's less then nMasternodePaymentsIncreaseBlock
         consensus.nMasternodePaymentsIncreaseBlock = 1569325056; // actual historical value
         consensus.nMasternodePaymentsIncreasePeriod = 1569325056; // 17280 - actual historical value
         consensus.nInstantSendKeepLock = 24;
-        consensus.nBudgetPaymentsStartBlock = 328008; // actual historical value
+        consensus.nBudgetPaymentsStartBlock = 100000; // set to actual historical value on the hardfork moment(differs from 33001-66000 block height advertised on the http://omegacoin.network/index-2.html)
         consensus.nBudgetPaymentsCycleBlocks = 16616; // ~(60*24*30)/2.6, actual number of blocks per month is 200700 / 12 = 16725
         consensus.nBudgetPaymentsWindowBlocks = 100;
         consensus.nBudgetProposalEstablishingTime = 60*60*24;


### PR DESCRIPTION
 # Current Dash implementation for block reward
 Block creation [method](https://github.com/dashpay/dash/blob/master/src/miner.cpp#L286) calculates block [reward]( https://github.com/dashpay/dash/blob/master/src/validation.cpp#L1231) . And masternode payments deduction from block reward is here - [link](https://github.com/dashpay/dash/blob/master/src/masternode-payments.cpp#L288).
Thread where decrease explained: [link](https://www.reddit.com/r/dashpay/comments/610xm9/block_reward_calculation/)

# Current Omega implementation for block reward
Block creation [method](https://github.com/omegacoinnetwork/omegacoin/blob/master/src/miner.cpp#L286) calculates block [reward]( https://github.com/omegacoinnetwork/omegacoin/blob/master/src/validation.cpp#L1231).And masternode payments deduction from block reward is here - [link](https://github.com/omegacoinnetwork/omegacoin/blob/master/src/masternode-payments.cpp#L288)

# Python forecasting application to get projection for coins generated by year 2025+
Value used in source code for percentage is 1/3.8556 but to get 18.9M cap I found 1/3.803 to suite better. By any means the code proposed here needs to be compiled and test and further thinking done 
by playing in python app, also putting more logic similar to actual omega code in that python code to get more understanding on how select correct value for omega code that will produce hardfork : [Python App For OMEGA Forcasts](https://repl.it/@Zacorich/Omega-Forecasts)